### PR TITLE
Fix for #58: Reset the existing token before we start a new authentication

### DIFF
--- a/src/main/java/io/camunda/tasklist/CamundaTaskListClient.java
+++ b/src/main/java/io/camunda/tasklist/CamundaTaskListClient.java
@@ -476,6 +476,8 @@ public class CamundaTaskListClient {
     if (this.properties.alwaysReconnect ||
             (this.tokenExpiration > 0
         && this.tokenExpiration < (System.currentTimeMillis() - 1000))) {
+        // reset old Token before a new authentication
+        properties.authentication.resetToken(Product.TASKLIST);
         authenticate();
     }
   }


### PR DESCRIPTION
Hi. We have the same problem did a small investigation. We found that the Authentication-Classes from the common package did not reset the token. So here is a PR to fix this issue.